### PR TITLE
Fix README/pod links to setup-*-yml.pl scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ version 0.05
 
 # DESCRIPTION
 
-This distro includes two command-line tools, [update-travis-yml.pl](https://metacpan.org/pod/update-travis-yml.pl) and
-[update-appveyor-yml.pl](https://metacpan.org/pod/update-appveyor-yml.pl). They update Travis and AppVeyor YAML config files
+This distro includes two command-line tools, [setup-travis-yml.pl](https://metacpan.org/pod/setup-travis-yml.pl) and
+[setup-appveyor-yml.pl](https://metacpan.org/pod/setup-appveyor-yml.pl). They update Travis and AppVeyor YAML config files
 with some opinionated defaults. See the docs for the respective scripts for
 more details.
 

--- a/lib/App/CISetup.pm
+++ b/lib/App/CISetup.pm
@@ -19,8 +19,8 @@ __END__
 
 =head1 DESCRIPTION
 
-This distro includes two command-line tools, L<update-travis-yml.pl> and
-L<update-appveyor-yml.pl>. They update Travis and AppVeyor YAML config files
+This distro includes two command-line tools, L<setup-travis-yml.pl> and
+L<setup-appveyor-yml.pl>. They update Travis and AppVeyor YAML config files
 with some opinionated defaults. See the docs for the respective scripts for
 more details.
 


### PR DESCRIPTION
Both the README.md and App::CISetup pod refer to update-*-yml.pl
scripts, but the dist contains only setup-*-yml.pl scripts, which
results in e.g. 404s in MetaCPAN..  Update the links accordingly.