### PR TITLE
Capture return value of update_file inside try block

### DIFF
--- a/lib/App/CISetup/Role/ConfigUpdater.pm
+++ b/lib/App/CISetup/Role/ConfigUpdater.pm
@@ -75,8 +75,9 @@ sub _update_files {
         $file = path($file);
 
         $count++;
-        my $updated = try {
-            $self->_config_file_class->new( $self->_cf_params($file) )
+        my $updated;
+        try {
+            $updated = $self->_config_file_class->new( $self->_cf_params($file) )
                 ->update_file;
         }
         catch {


### PR DESCRIPTION
This fixes the issue below.  Note that even though the YAML file was not
parsed, it was still reported as having been updated.

$ perl -Ilib bin/setup-travis-yml.pl --dir ../URI

../URI/.travis.yml
YAML parsing error: YAML Error: Couldn't parse single line value
   Code: YAML_PARSE_ERR_SINGLE_LINE
   Line: 14
   Document: 1
 at /Users/olaf/.plenv/versions/5.26.1/lib/perl5/site_perl/5.26.1/YAML/Loader.pm line 147.

Updated ../URI/.travis.yml