### PR TITLE
Make fewer assumptions about existing config.

### DIFF
--- a/lib/App/CISetup/Travis/ConfigFile.pm
+++ b/lib/App/CISetup/Travis/ConfigFile.pm
@@ -211,7 +211,8 @@ sub _update_perl_matrix {
     my @allow_failures = @{ $travis->{matrix}{allow_failures} // [] };
     for my $blead (@bleads) {
         push @allow_failures, { perl => $blead }
-            unless grep { $_->{perl} eq $blead } @allow_failures;
+            unless grep { exists $_->{perl} && $_->{perl} eq $blead }
+            @allow_failures;
     }
 
     $travis->{matrix} = {


### PR DESCRIPTION
This change allows ConfigFile.pm to deal with something like the
following YAML:

```yaml
 matrix:
    allow_failures:
      -
        env: COVERAGE=1
    fast_finish: 'true'
    include:
      -
        env: COVERAGE=1
        perl: '5.26'
```

Note that allow_failures has an env var, but doesn't define a Perl version.